### PR TITLE
Fix exports

### DIFF
--- a/component-playground/lib/get-component-fixture-tree.js
+++ b/component-playground/lib/get-component-fixture-tree.js
@@ -22,7 +22,7 @@ module.exports = function() {
       };
     }
 
-    fixtures[componentName].fixtures[fixtureName] = requireFixture(fixturePath);
+    fixtures[componentName].fixtures[fixtureName] = requireFixture(fixturePath).default;
   });
 
   return fixtures;

--- a/component-playground/lib/get-component-fixture-tree.js
+++ b/component-playground/lib/get-component-fixture-tree.js
@@ -9,10 +9,15 @@ module.exports = function() {
         componentName = pathParts[1],
         fixtureName = pathParts[2];
 
+    var componentFileExport = require('components/' + componentName + '/index.jsx');
+    // hack – fixes problem where using ES6 named export from component .jsx file breaks webpack require.
+    if (!(typeof(componentFileExport) == 'function') && componentFileExport.default) {
+      componentFileExport = componentFileExport.default;
+    }
     // Fixtures are grouped per component
     if (!fixtures[componentName]) {
       fixtures[componentName] = {
-        class: require('components/' + componentName + '/index.jsx'),
+        class: componentFileExport,
         fixtures: {}
       };
     }


### PR DESCRIPTION
Before,

```
export const foo

export default { }
```

combining named + default exports in a single file would break cosmos.
Also would cause problems in fixture files.

Now you can.  This is a little opinionated in the other direction – assumes that component files always put the React class in the default export – there are better fixes we can implement for this in the future that allow more flexibility, this was just a quick hack.
