### PR TITLE
Update late font to match patreon_py

### DIFF
--- a/component-playground/public/index.html
+++ b/component-playground/public/index.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <title>React Component Playground</title>
   <!-- Patreon font -->
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,100,300,700,900,400italic'
+  <link href='http://fonts.googleapis.com/css?family=Lato:400,100,100italic,300,300italic,400italic,500,700,700italic,900,900italic'
             rel='stylesheet'
             type='text/css'>
 </head>


### PR DESCRIPTION
Rendering Lato was broken for certain font renderings (especially around italics).
